### PR TITLE
Fix title retrieval bug

### DIFF
--- a/src/LinkSaver/Models/Link.cs
+++ b/src/LinkSaver/Models/Link.cs
@@ -14,8 +14,8 @@ namespace LinkSaver.Models
 
         public string prependUrl()
         {
-            string prependedUrl = url.ToLower();
-            if (!prependedUrl.Contains(@"http://") && !prependedUrl.Contains(@"https://"))
+            string prependedUrl = url;
+            if (!prependedUrl.ToLower().Contains(@"http://") && !prependedUrl.ToLower().Contains(@"https://"))
             {
                 prependedUrl = "http://" + prependedUrl;
             }

--- a/src/LinkSaver/Models/LinkRepository.cs
+++ b/src/LinkSaver/Models/LinkRepository.cs
@@ -153,8 +153,17 @@ namespace LinkSaver.Models
                 html.LoadHtml(body);
 
                 html.OptionFixNestedTags = true;
+                
                 var s = html.DocumentNode.Descendants("title").SingleOrDefault();
-                 title = s.InnerText;
+                if(s == null)
+                {
+                    title = "no title";
+                }
+                else
+                {
+                    title = s.InnerText;
+                }
+              
                 
             }
             else


### PR DESCRIPTION
this branch fixed a bug which occured when a retrieved page's HTML had no title node. previously, the code would still attempt to reference an object which threw an error if it did not exist -- now, an if condition checks if the object variable is null, and sets title to "no title" in that case. 